### PR TITLE
Properly determine branch name for pull_request and push events

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,15 @@ const core = require('@actions/core');
 
 async function run() {
   try {
-    core.exportVariable('BRANCH_NAME', process.env.GITHUB_REF.split('/').slice(2).join('/'));
+    const event = JSON.parse( readFileSync( GITHUB_EVENT_PATH, 'utf8' ) );
+		const isPullRequest = !! event.pull_request;
+    let branchName;
+    if ( this.isPullRequest ) {
+      branchName = event.pull_request.head.ref;
+    } else {
+      branchName = event.ref.substr( 11 );
+    }
+    core.exportVariable('BRANCH_NAME', branchName);
   }
   catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
`process.env.GITHUB_REF.split('/').slice(2).join('/')` does not work for a `pull_request` event. 

The suggested approach should cover both `push` and `pull_request` events