### PR TITLE
Use Node v16 instead of v12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,5 +4,5 @@ branding:
   icon: 'git-branch'
   color: 'blue'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
This resolves #15 which should get rid of the warning

```
The following actions uses node12 which is deprecated and will be forced to run on node16
```